### PR TITLE
Rename sca.py to ccd.py

### DIFF
--- a/euclidlike_imsim/__init__.py
+++ b/euclidlike_imsim/__init__.py
@@ -1,5 +1,6 @@
 try:
     from lsst.utils.threads import disable_implicit_threading
+
     disable_implicit_threading()
 except:
     pass
@@ -11,4 +12,5 @@ from .wcs import *
 from .skycat import *
 from .photonOps import *
 from .bandpass import *
+
 # from .detector_physics import *

--- a/euclidlike_imsim/ccd.py
+++ b/euclidlike_imsim/ccd.py
@@ -10,6 +10,7 @@ import numpy as np
 
 import euclidlike
 
+
 class EuclidlikeCCDImageBuilder(ScatteredImageBuilder):
 
     def setup(self, config, base, image_num, obj_num, ignore, logger):
@@ -29,55 +30,63 @@ class EuclidlikeCCDImageBuilder(ScatteredImageBuilder):
         Returns:
             xsize, ysize
         """
-        logger.debug('image %d: Building EuclidlikeCCD: image, obj = %d,%d',
-                     image_num,image_num,obj_num)
+        logger.debug(
+            "image %d: Building EuclidlikeCCD: image, obj = %d,%d",
+            image_num,
+            image_num,
+            obj_num,
+        )
 
         self.nobjects = self.getNObj(config, base, image_num, logger=logger)
-        logger.debug('image %d: nobj = %d',image_num,self.nobjects)
+        logger.debug("image %d: nobj = %d", image_num, self.nobjects)
 
         # These are allowed for Scattered, but we don't use them here.
-        extra_ignore = [ 'image_pos', 'world_pos', 'stamp_size', 'stamp_xsize', 'stamp_ysize',
-                         'nobjects' ]
-        req = {
-            'CCD' : int,
-            'filter' : str,
-            'mjd'  : float,
-            'exptime' : float
-        }
+        extra_ignore = [
+            "image_pos",
+            "world_pos",
+            "stamp_size",
+            "stamp_xsize",
+            "stamp_ysize",
+            "nobjects",
+        ]
+        req = {"CCD": int, "filter": str, "mjd": float, "exptime": float}
         opt = {
-            'draw_method' : str,
-            'stray_light' : bool,
-            'thermal_background' : bool,
-            'reciprocity_failure' : bool,
-            'dark_current' : bool,
-            'nonlinearity' : bool,
-            'ipc' : bool,
-            'read_noise' : bool,
-            'sky_subtract' : bool,
-            'ignore_noise' : bool
+            "draw_method": str,
+            "stray_light": bool,
+            "thermal_background": bool,
+            "reciprocity_failure": bool,
+            "dark_current": bool,
+            "nonlinearity": bool,
+            "ipc": bool,
+            "read_noise": bool,
+            "sky_subtract": bool,
+            "ignore_noise": bool,
         }
-        params = galsim.config.GetAllParams(config, base, req=req, opt=opt, ignore=ignore+extra_ignore)[0]
+        params = galsim.config.GetAllParams(
+            config, base, req=req, opt=opt, ignore=ignore + extra_ignore
+        )[0]
 
-        self.ccd = params['CCD']
-        base['CCD'] = self.ccd
-        self.filter = params['filter']
-        self.mjd = params['mjd']
-        self.exptime = params['exptime']
+        self.ccd = params["CCD"]
+        base["CCD"] = self.ccd
+        self.filter = params["filter"]
+        self.mjd = params["mjd"]
+        self.exptime = params["exptime"]
 
-        self.ignore_noise = params.get('ignore_noise',False)
+        self.ignore_noise = params.get("ignore_noise", False)
         # self.exptime = params.get('exptime', roman.exptime)  # Default is roman standard exposure time.
-        self.stray_light = params.get('stray_light', False)
-        self.thermal_background = params.get('thermal_background', False)
-        self.reciprocity_failure = params.get('reciprocity_failure', False)
-        self.dark_current = params.get('dark_current', False)
-        self.nonlinearity = params.get('nonlinearity', False)
-        self.ipc = params.get('ipc', False)
-        self.read_noise = params.get('read_noise', False)
-        self.sky_subtract = params.get('sky_subtract', False)
+        self.stray_light = params.get("stray_light", False)
+        self.thermal_background = params.get("thermal_background", False)
+        self.reciprocity_failure = params.get("reciprocity_failure", False)
+        self.dark_current = params.get("dark_current", False)
+        self.nonlinearity = params.get("nonlinearity", False)
+        self.ipc = params.get("ipc", False)
+        self.read_noise = params.get("read_noise", False)
+        self.sky_subtract = params.get("sky_subtract", False)
 
         # If draw_method isn't in image field, it may be in stamp.  Check.
-        self.draw_method = params.get('draw_method',
-                                      base.get('stamp',{}).get('draw_method','auto'))
+        self.draw_method = params.get(
+            "draw_method", base.get("stamp", {}).get("draw_method", "auto")
+        )
 
         # pointing = CelestialCoord(ra=params['ra'], dec=params['dec'])
         # wcs = roman.getWCS(world_pos        = pointing,
@@ -91,8 +100,10 @@ class EuclidlikeCCDImageBuilder(ScatteredImageBuilder):
         # config['wcs'] = wcs
 
         # If user hasn't overridden the bandpass to use, get the standard one.
-        if 'bandpass' not in config:
-            base['bandpass'] = galsim.config.BuildBandpass(base['image'], 'bandpass', base, logger=logger)
+        if "bandpass" not in config:
+            base["bandpass"] = galsim.config.BuildBandpass(
+                base["image"], "bandpass", base, logger=logger
+            )
 
         return euclidlike.n_pix_col, euclidlike.n_pix_row
 
@@ -114,51 +125,61 @@ class EuclidlikeCCDImageBuilder(ScatteredImageBuilder):
         Returns:
             the final image and the current noise variance in the image as a tuple
         """
-        full_xsize = base['image_xsize']
-        full_ysize = base['image_ysize']
-        wcs = base['wcs']
+        full_xsize = base["image_xsize"]
+        full_ysize = base["image_ysize"]
+        wcs = base["wcs"]
 
         full_image = Image(full_xsize, full_ysize, dtype=float)
-        full_image.setOrigin(base['image_origin'])
+        full_image.setOrigin(base["image_origin"])
         full_image.wcs = wcs
         full_image.setZero()
 
         full_image.header = galsim.FitsHeader()
-        full_image.header['EXPTIME']  = self.exptime
-        full_image.header['MJD-OBS']  = self.mjd
-        full_image.header['DATE-OBS'] = str(Time(self.mjd,format='mjd').datetime)
-        full_image.header['FILTER']   = self.filter
-        full_image.header['ZPTMAG']   = 2.5*np.log10(self.exptime*euclidlike.collecting_area)
+        full_image.header["EXPTIME"] = self.exptime
+        full_image.header["MJD-OBS"] = self.mjd
+        full_image.header["DATE-OBS"] = str(Time(self.mjd, format="mjd").datetime)
+        full_image.header["FILTER"] = self.filter
+        full_image.header["ZPTMAG"] = 2.5 * np.log10(
+            self.exptime * euclidlike.collecting_area
+        )
 
-        base['current_image'] = full_image
+        base["current_image"] = full_image
 
-        if 'image_pos' in config and 'world_pos' in config:
+        if "image_pos" in config and "world_pos" in config:
             raise GalSimConfigValueError(
                 "Both image_pos and world_pos specified for Scattered image.",
-                (config['image_pos'], config['world_pos']))
+                (config["image_pos"], config["world_pos"]),
+            )
 
-        if 'image_pos' not in config and 'world_pos' not in config:
-            xmin = base['image_origin'].x
-            xmax = xmin + full_xsize-1
-            ymin = base['image_origin'].y
-            ymax = ymin + full_ysize-1
-            config['image_pos'] = {
-                'type' : 'XY' ,
-                'x' : { 'type' : 'Random' , 'min' : xmin , 'max' : xmax },
-                'y' : { 'type' : 'Random' , 'min' : ymin , 'max' : ymax }
+        if "image_pos" not in config and "world_pos" not in config:
+            xmin = base["image_origin"].x
+            xmax = xmin + full_xsize - 1
+            ymin = base["image_origin"].y
+            ymax = ymin + full_ysize - 1
+            config["image_pos"] = {
+                "type": "XY",
+                "x": {"type": "Random", "min": xmin, "max": xmax},
+                "y": {"type": "Random", "min": ymin, "max": ymax},
             }
 
         nbatch = self.nobjects // 1000 + 1
         for batch in range(nbatch):
-            start_obj_num = (self.nobjects * batch // nbatch)
-            end_obj_num = (self.nobjects * (batch+1) // nbatch)
+            start_obj_num = self.nobjects * batch // nbatch
+            end_obj_num = self.nobjects * (batch + 1) // nbatch
             nobj_batch = end_obj_num - start_obj_num
             if nbatch > 1:
-                logger.warning("Start batch %d/%d with %d objects [%d, %d)",
-                               batch+1, nbatch, nobj_batch, start_obj_num, end_obj_num)
+                logger.warning(
+                    "Start batch %d/%d with %d objects [%d, %d)",
+                    batch + 1,
+                    nbatch,
+                    nobj_batch,
+                    start_obj_num,
+                    end_obj_num,
+                )
             stamps, current_vars = galsim.config.BuildStamps(
-                    nobj_batch, base, logger=logger, obj_num=start_obj_num, do_noise=False)
-            base['index_key'] = 'image_num'
+                nobj_batch, base, logger=logger, obj_num=start_obj_num, do_noise=False
+            )
+            base["index_key"] = "image_num"
 
             for k in range(nobj_batch):
                 # This is our signal that the object was skipped.
@@ -171,12 +192,18 @@ class EuclidlikeCCDImageBuilder(ScatteredImageBuilder):
                     # avoid an error.  But this isn't covered in the imsim test suite.
                     continue
 
-                logger.debug('image %d: full bounds = %s', image_num, str(full_image.bounds))
-                logger.debug('image %d: stamp %d bounds = %s',
-                        image_num, k+start_obj_num, str(stamps[k].bounds))
-                logger.debug('image %d: Overlap = %s', image_num, str(bounds))
+                logger.debug(
+                    "image %d: full bounds = %s", image_num, str(full_image.bounds)
+                )
+                logger.debug(
+                    "image %d: stamp %d bounds = %s",
+                    image_num,
+                    k + start_obj_num,
+                    str(stamps[k].bounds),
+                )
+                logger.debug("image %d: Overlap = %s", image_num, str(bounds))
                 full_image[bounds] += stamps[k][bounds]
-            stamps=None
+            stamps = None
 
         # # Bring the image so far up to a flat noise variance
         # current_var = FlattenNoiseVariance(
@@ -200,21 +227,23 @@ class EuclidlikeCCDImageBuilder(ScatteredImageBuilder):
         if self.ignore_noise:
             return
 
-        base['current_noise_image'] = base['current_image']
-        wcs = base['wcs']
-        bp = base['bandpass']
+        base["current_noise_image"] = base["current_image"]
+        wcs = base["wcs"]
+        bp = base["bandpass"]
         rng = galsim.config.GetRNG(config, base)
-        logger.info('image %d: Start EuclidlikeCCD detector effects',base.get('image_num',0))
+        logger.info(
+            "image %d: Start EuclidlikeCCD detector effects", base.get("image_num", 0)
+        )
 
         # Things that will eventually be subtracted (if sky_subtract) will have their expectation
         # value added to sky_image.  So technically, this includes things that aren't just sky.
         # E.g. includes dark_current and thermal backgrounds.
         sky_image = image.copy()
         sky_level = euclidlike.getSkyLevel(bp, world_pos=wcs.toWorld(image.true_center))
-        logger.debug('Adding sky_level = %s',sky_level)
+        logger.debug("Adding sky_level = %s", sky_level)
         if self.stray_light:
-            logger.debug('Stray light fraction = %s',stray_light_fraction)
-            sky_level *= (1.0 + stray_light_fraction)
+            logger.debug("Stray light fraction = %s", stray_light_fraction)
+            sky_level *= 1.0 + stray_light_fraction
         wcs.makeSkyImage(sky_image, sky_level)
 
         # The other background is the expected thermal backgrounds in this band.
@@ -227,12 +256,12 @@ class EuclidlikeCCDImageBuilder(ScatteredImageBuilder):
         # The image up to here is an expectation value.
         # Realize it as an integer number of photons.
         poisson_noise = galsim.noise.PoissonNoise(rng)
-        if self.draw_method == 'phot':
+        if self.draw_method == "phot":
             logger.debug("Adding poisson noise to sky photons")
             sky_image1 = sky_image.copy()
             sky_image1.addNoise(poisson_noise)
             image.quantize()  # In case any profiles used InterpolatedImage, in which case
-                              # the image won't necessarily be integers.
+            # the image won't necessarily be integers.
             image += sky_image1
         else:
             logger.debug("Adding poisson noise")
@@ -249,19 +278,20 @@ class EuclidlikeCCDImageBuilder(ScatteredImageBuilder):
         # The order we chose is historical, matching previous recommendations, but Mosby and
         # Rauscher don't seem to think those recommendations are well-motivated.
 
-
         if self.dark_current:
             dc = dark_current * self.exptime
-            logger.debug("Adding dark current: %s",dc)
+            logger.debug("Adding dark current: %s", dc)
             sky_image += dc
-            dark_noise = galsim.noise.DeviateNoise(galsim.random.PoissonDeviate(rng, dc))
+            dark_noise = galsim.noise.DeviateNoise(
+                galsim.random.PoissonDeviate(rng, dc)
+            )
             image.addNoise(dark_noise)
 
         if self.read_noise:
-            logger.debug("Adding read noise %s",read_noise)
+            logger.debug("Adding read noise %s", read_noise)
             image.addNoise(GaussianNoise(rng, sigma=read_noise))
 
-        logger.debug("Applying gain %s",gain)
+        logger.debug("Applying gain %s", gain)
         image /= gain
 
         # Make integer ADU now.
@@ -273,5 +303,6 @@ class EuclidlikeCCDImageBuilder(ScatteredImageBuilder):
             sky_image.quantize()
             image -= sky_image
 
+
 # Register this as a valid type
-RegisterImageType('euclidlike_ccd', EuclidlikeCCDImageBuilder())
+RegisterImageType("euclidlike_ccd", EuclidlikeCCDImageBuilder())

--- a/euclidlike_imsim/obseq.py
+++ b/euclidlike_imsim/obseq.py
@@ -3,14 +3,14 @@ import fitsio as fio
 import galsim
 import galsim.config
 from galsim.angle import Angle
-from galsim.config import InputLoader,RegisterValueType,RegisterInputType
+from galsim.config import InputLoader, RegisterValueType, RegisterInputType
+
 
 class ObSeqDataLoader(object):
-    """Read the exposure information from the observation sequence.
-    """
-    _req_params = {'file_name' : str,
-                    'visit'    : int,
-                    'CCD'      : int}
+    """Read the exposure information from the observation sequence."""
+
+    _req_params = {"file_name": str, "visit": int, "CCD": int}
+
     def __init__(self, file_name, visit, CCD, logger=None):
         self.logger = galsim.config.LoggerWrapper(logger)
         self.file_name = file_name
@@ -26,41 +26,51 @@ class ObSeqDataLoader(object):
     def read_obseq(self):
         """Read visit info from the obseq file."""
         if self.file_name is None:
-            raise ValueError('No obseq filename provided, trying to build from config information.')
+            raise ValueError(
+                "No obseq filename provided, trying to build from config information."
+            )
         if self.visit is None:
-            raise ValueError('The visit must be set when reading visit info from an obseq file.')
+            raise ValueError(
+                "The visit must be set when reading visit info from an obseq file."
+            )
 
-        self.logger.warning('Reading info from obseq file %s for visit %s',
-                            self.file_name, self.visit)
+        self.logger.warning(
+            "Reading info from obseq file %s for visit %s", self.file_name, self.visit
+        )
 
         ob = fio.FITS(self.file_name)[-1][self.visit]
 
-        self.ob            = {}
-        self.ob['visit']   = self.visit
-        self.ob['ccd']     = self.ccd
-        self.ob['ra']      = ob['ra']*galsim.degrees
-        self.ob['dec']     = ob['dec']*galsim.degrees
-        self.ob['pa']      = ob['pa'] *galsim.degrees
-        self.ob['date']    = Time(ob['date'],format='mjd').datetime 
-        self.ob['mjd']     = ob['date']
-        self.ob['filter']  = ob['filter']
-        self.ob['exptime'] = ob['exptime']
+        self.ob = {}
+        self.ob["visit"] = self.visit
+        self.ob["ccd"] = self.ccd
+        self.ob["ra"] = ob["ra"] * galsim.degrees
+        self.ob["dec"] = ob["dec"] * galsim.degrees
+        self.ob["pa"] = ob["pa"] * galsim.degrees
+        self.ob["date"] = Time(ob["date"], format="mjd").datetime
+        self.ob["mjd"] = ob["date"]
+        self.ob["filter"] = ob["filter"]
+        self.ob["exptime"] = ob["exptime"]
 
     def get(self, field, default=None):
         if field not in self.ob and default is None:
-            raise KeyError("OpsimData field %s not present in ob"%field)
+            raise KeyError("OpsimData field %s not present in ob" % field)
         return self.ob.get(field, default)
 
+
 def ObSeqData(config, base, value_type):
-    """Returns the obseq data for a pointing.
-    """
-    pointing = galsim.config.GetInputObj('obseq_data', config, base, 'OpSeqDataLoader')
-    req = { 'field' : str }
+    """Returns the obseq data for a pointing."""
+    pointing = galsim.config.GetInputObj("obseq_data", config, base, "OpSeqDataLoader")
+    req = {"field": str}
     kwargs, safe = galsim.config.GetAllParams(config, base, req=req)
-    field = kwargs['field']
+    field = kwargs["field"]
 
     val = value_type(pointing.get(field))
     return val, safe
 
-RegisterInputType('obseq_data', InputLoader(ObSeqDataLoader, file_scope=True, takes_logger=True))
-RegisterValueType('ObSeqData', ObSeqData, [float, int, str, Angle], input_type='obseq_data')
+
+RegisterInputType(
+    "obseq_data", InputLoader(ObSeqDataLoader, file_scope=True, takes_logger=True)
+)
+RegisterValueType(
+    "ObSeqData", ObSeqData, [float, int, str, Angle], input_type="obseq_data"
+)

--- a/euclidlike_imsim/psf.py
+++ b/euclidlike_imsim/psf.py
@@ -1,83 +1,105 @@
 import galsim
 import galsim.roman as roman
 import galsim.config
-from galsim.config import RegisterObjectType,RegisterInputType,OpticalPSF,InputLoader
+from galsim.config import RegisterObjectType, RegisterInputType, OpticalPSF, InputLoader
 
 import euclidlike
 
+
 class RomanPSF(object):
-    """Class building needed Roman PSFs.
-    """
-    def __init__(self, CCD=None, WCS=None, n_waves=None, bpass=None, extra_aberrations=None, logger=None):
+    """Class building needed Roman PSFs."""
+
+    def __init__(
+        self,
+        CCD=None,
+        WCS=None,
+        n_waves=None,
+        bpass=None,
+        extra_aberrations=None,
+        logger=None,
+    ):
 
         logger = galsim.config.LoggerWrapper(logger)
 
         if n_waves == -1:
-            if bpass.name=='W146':
-                n_waves=10
+            if bpass.name == "W146":
+                n_waves = 10
             else:
-                n_waves=5
+                n_waves = 5
 
-        corners = [galsim.PositionD(1,1),galsim.PositionD(1,euclidlike.n_pix_col),galsim.PositionD(euclidlike.n_pix_row,1),galsim.PositionD(euclidlike.n_pix_row, euclidlike.n_pix_col)]
-        cc = galsim.PositionD(euclidlike.n_pix_row/2, euclidlike.n_pix_col/2)
-        tags = ['ll','lu','ul','uu']
+        corners = [
+            galsim.PositionD(1, 1),
+            galsim.PositionD(1, euclidlike.n_pix_col),
+            galsim.PositionD(euclidlike.n_pix_row, 1),
+            galsim.PositionD(euclidlike.n_pix_row, euclidlike.n_pix_col),
+        ]
+        cc = galsim.PositionD(euclidlike.n_pix_row / 2, euclidlike.n_pix_col / 2)
+        tags = ["ll", "lu", "ul", "uu"]
         self.PSF = {}
         pupil_bin = 8
         self.PSF[pupil_bin] = {}
-        for tag,CCD_pos in tuple(zip(tags,corners)):
-            self.PSF[pupil_bin][tag] = self._psf_call(CCD,bpass,CCD_pos,WCS,pupil_bin,n_waves,logger,extra_aberrations)
-        for pupil_bin in [4,2,'achromatic']:
-            self.PSF[pupil_bin] = self._psf_call(CCD,bpass,cc,WCS,pupil_bin,n_waves,logger,extra_aberrations)
+        for tag, CCD_pos in tuple(zip(tags, corners)):
+            self.PSF[pupil_bin][tag] = self._psf_call(
+                CCD, bpass, CCD_pos, WCS, pupil_bin, n_waves, logger, extra_aberrations
+            )
+        for pupil_bin in [4, 2, "achromatic"]:
+            self.PSF[pupil_bin] = self._psf_call(
+                CCD, bpass, cc, WCS, pupil_bin, n_waves, logger, extra_aberrations
+            )
 
-    def _parse_pupil_bin(self,pupil_bin):
-        if pupil_bin=='achromatic':
+    def _parse_pupil_bin(self, pupil_bin):
+        if pupil_bin == "achromatic":
             return 8
         else:
             return pupil_bin
 
-    def _psf_call(self,CCD,bpass,CCD_pos,WCS,pupil_bin,n_waves,logger,extra_aberrations):
+    def _psf_call(
+        self, CCD, bpass, CCD_pos, WCS, pupil_bin, n_waves, logger, extra_aberrations
+    ):
 
-        if pupil_bin==8:
-            psf = roman.getPSF(CCD,
-                    bpass.name,
-                    SCA_pos             = CCD_pos,
-                    wcs                 = WCS,
-                    pupil_bin           = pupil_bin,
-                    n_waves             = n_waves,
-                    logger              = logger,
-                    # Don't set wavelength for this one.
-                    # We want this to be chromatic for photon shooting.
-                    # wavelength          = bpass.effective_wavelength,
-                    extra_aberrations   = extra_aberrations
-                    )
+        if pupil_bin == 8:
+            psf = roman.getPSF(
+                CCD,
+                bpass.name,
+                SCA_pos=CCD_pos,
+                wcs=WCS,
+                pupil_bin=pupil_bin,
+                n_waves=n_waves,
+                logger=logger,
+                # Don't set wavelength for this one.
+                # We want this to be chromatic for photon shooting.
+                # wavelength          = bpass.effective_wavelength,
+                extra_aberrations=extra_aberrations,
+            )
         else:
-            psf = roman.getPSF(CCD,
-                    bpass.name,
-                    SCA_pos             = CCD_pos,
-                    wcs                 = WCS,
-                    pupil_bin           = self._parse_pupil_bin(pupil_bin),
-                    n_waves             = n_waves,
-                    logger              = logger,
-                    # Note: setting wavelength makes it achromatic.
-                    # We only use pupil_bin = 2,4 for FFT objects.
-                    wavelength          = bpass.effective_wavelength,
-                    extra_aberrations   = extra_aberrations
-                    )
-        if pupil_bin==4:
+            psf = roman.getPSF(
+                CCD,
+                bpass.name,
+                SCA_pos=CCD_pos,
+                wcs=WCS,
+                pupil_bin=self._parse_pupil_bin(pupil_bin),
+                n_waves=n_waves,
+                logger=logger,
+                # Note: setting wavelength makes it achromatic.
+                # We only use pupil_bin = 2,4 for FFT objects.
+                wavelength=bpass.effective_wavelength,
+                extra_aberrations=extra_aberrations,
+            )
+        if pupil_bin == 4:
             return psf.withGSParams(maximum_fft_size=16384, folding_threshold=1e-3)
-        elif pupil_bin==2:
+        elif pupil_bin == 2:
             return psf.withGSParams(maximum_fft_size=16384, folding_threshold=1e-4)
         else:
             return psf.withGSParams(maximum_fft_size=16384)
 
-    def getPSF(self,pupil_bin,pos):
+    def getPSF(self, pupil_bin, pos):
         """
         Return a PSF to be convolved with sources.
 
         @param [in] what pupil binning to request.
         """
 
-        #temporary
+        # temporary
         # psf = self.PSF[pupil_bin]['ll']
         # if ((pos.x-roman.n_pix)**2+(pos.y-roman.n_pix)**2)<((pos.x-1)**2+(pos.y-1)**2):
         #     psf = self.PSF[pupil_bin]['uu']
@@ -90,53 +112,64 @@ class RomanPSF(object):
         # return psf
 
         psf = self.PSF[pupil_bin]
-        if pupil_bin!=8:
+        if pupil_bin != 8:
             return psf
 
-        wll = (euclidlike.n_pix_col-pos.x)*(euclidlike.n_pix_row-pos.y)
-        wlu = (euclidlike.n_pix_col-pos.x)*(pos.y-1)
-        wul = (pos.x-1)*(euclidlike.n_pix_row-pos.y)
-        wuu = (pos.x-1)*(pos.y-1)
-        return (wll*psf['ll']+wlu*psf['lu']+wul*psf['ul']+wuu*psf['uu'])/((euclidlike.n_pix_row-1)*(euclidlike.n_pix_col-1))
+        wll = (euclidlike.n_pix_col - pos.x) * (euclidlike.n_pix_row - pos.y)
+        wlu = (euclidlike.n_pix_col - pos.x) * (pos.y - 1)
+        wul = (pos.x - 1) * (euclidlike.n_pix_row - pos.y)
+        wuu = (pos.x - 1) * (pos.y - 1)
+        return (
+            wll * psf["ll"] + wlu * psf["lu"] + wul * psf["ul"] + wuu * psf["uu"]
+        ) / ((euclidlike.n_pix_row - 1) * (euclidlike.n_pix_col - 1))
+
 
 class PSFLoader(InputLoader):
-    """PSF loader.
-    """
+    """PSF loader."""
+
     def __init__(self):
         # Override some defaults in the base init.
-        super().__init__(init_func=RomanPSF,
-                         takes_logger=True, use_proxy=False)
+        super().__init__(init_func=RomanPSF, takes_logger=True, use_proxy=False)
 
     def getKwargs(self, config, base, logger):
         logger.debug("Get kwargs for PSF")
 
         req = {}
         opt = {
-            'n_waves' : int,
+            "n_waves": int,
         }
-        ignore = ['extra_aberrations']
+        ignore = ["extra_aberrations"]
 
         # If SCA is in base, then don't require it in the config file.
         # (Presumably because using Roman image type, which sets it there for convenience.)
-        if 'CCD' in base:
-            opt['CCD'] = int
+        if "CCD" in base:
+            opt["CCD"] = int
         else:
-            req['CCD'] = int
+            req["CCD"] = int
 
-        kwargs, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt, ignore=ignore)
+        kwargs, safe = galsim.config.GetAllParams(
+            config, base, req=req, opt=opt, ignore=ignore
+        )
 
         # If not given in kwargs, then it must have been in base, so this is ok.
-        if 'CCD' not in kwargs:
-            kwargs['CCD'] = base['CCD']
+        if "CCD" not in kwargs:
+            kwargs["CCD"] = base["CCD"]
 
-        kwargs['extra_aberrations'] = galsim.config.ParseAberrations('extra_aberrations', config, base, 'RomanPSF')
-        kwargs['WCS']    = galsim.config.BuildWCS(base['image'], 'wcs', base, logger=logger)
-        kwargs['bpass']  = galsim.config.BuildBandpass(base['image'], 'bandpass', base, logger)[0]
+        kwargs["extra_aberrations"] = galsim.config.ParseAberrations(
+            "extra_aberrations", config, base, "RomanPSF"
+        )
+        kwargs["WCS"] = galsim.config.BuildWCS(
+            base["image"], "wcs", base, logger=logger
+        )
+        kwargs["bpass"] = galsim.config.BuildBandpass(
+            base["image"], "bandpass", base, logger
+        )[0]
 
-        logger.debug("kwargs = %s",kwargs)
+        logger.debug("kwargs = %s", kwargs)
 
         return kwargs, False
 
+
 # Register this as a valid type
-RegisterInputType('roman_psf', PSFLoader())
+RegisterInputType("roman_psf", PSFLoader())
 # RegisterObjectType('roman_psf', BuildRomanPSF, input_type='romanpsf_loader')

--- a/euclidlike_imsim/skycat.py
+++ b/euclidlike_imsim/skycat.py
@@ -1,22 +1,43 @@
 """
 Interface to obtain objects from skyCatalogs.
 """
+
 import os
 import numpy as np
 import galsim
-from galsim.config import InputLoader, RegisterInputType, RegisterValueType, \
-    RegisterObjectType
+from galsim.config import (
+    InputLoader,
+    RegisterInputType,
+    RegisterValueType,
+    RegisterObjectType,
+)
 
 import euclidlike
 
 
 class SkyCatalogInterface:
     """Interface to skyCatalogs package."""
-    _trivial_sed = galsim.SED(galsim.LookupTable([100, 2600], [1,1], interpolant='linear'),
-                              wave_type='nm', flux_type='fphotons')
 
-    def __init__(self, file_name, exptime, wcs=None, mjd=None, bandpass = None, xsize=None, ysize=None,
-                 obj_types=None, edge_pix=100, max_flux=None, logger=None):
+    _trivial_sed = galsim.SED(
+        galsim.LookupTable([100, 2600], [1, 1], interpolant="linear"),
+        wave_type="nm",
+        flux_type="fphotons",
+    )
+
+    def __init__(
+        self,
+        file_name,
+        exptime,
+        wcs=None,
+        mjd=None,
+        bandpass=None,
+        xsize=None,
+        ysize=None,
+        obj_types=None,
+        edge_pix=100,
+        max_flux=None,
+        logger=None,
+    ):
         """
         Parameters
         ----------
@@ -59,8 +80,10 @@ class SkyCatalogInterface:
         self.logger = galsim.config.LoggerWrapper(logger)
 
         if obj_types is not None:
-            self.logger.warning(f'Object types restricted to {obj_types}')
-        self.ccd_center = wcs.toWorld(galsim.PositionD(self.xsize/2.0, self.ysize/2.0))
+            self.logger.warning(f"Object types restricted to {obj_types}")
+        self.ccd_center = wcs.toWorld(
+            galsim.PositionD(self.xsize / 2.0, self.ysize / 2.0)
+        )
         self._objects = None
 
         # import os, psutil
@@ -70,30 +93,34 @@ class SkyCatalogInterface:
     @property
     def objects(self):
         from skycatalogs import skyCatalogs
+
         if self._objects is None:
             # import os, psutil
             # process = psutil.Process()
             # print('skycat obj 1',process.memory_info().rss)
             # Select objects from polygonal region bounded by CCD edges
-            corners = ((-self.edge_pix, -self.edge_pix),
-                       (self.xsize + self.edge_pix, -self.edge_pix),
-                       (self.xsize + self.edge_pix, self.ysize + self.edge_pix),
-                       (-self.edge_pix, self.ysize + self.edge_pix))
+            corners = (
+                (-self.edge_pix, -self.edge_pix),
+                (self.xsize + self.edge_pix, -self.edge_pix),
+                (self.xsize + self.edge_pix, self.ysize + self.edge_pix),
+                (-self.edge_pix, self.ysize + self.edge_pix),
+            )
             vertices = []
             for x, y in corners:
                 sky_coord = self.wcs.toWorld(galsim.PositionD(x, y))
-                vertices.append((sky_coord.ra/galsim.degrees,
-                                 sky_coord.dec/galsim.degrees))
+                vertices.append(
+                    (sky_coord.ra / galsim.degrees, sky_coord.dec / galsim.degrees)
+                )
             region = skyCatalogs.PolygonalRegion(vertices)
-            sky_cat = skyCatalogs.open_catalog(
-                self.file_name)
+            sky_cat = skyCatalogs.open_catalog(self.file_name)
             self._objects = sky_cat.get_objects_by_region(
-                region, obj_type_set=self.obj_types, mjd=self.mjd)
+                region, obj_type_set=self.obj_types, mjd=self.mjd
+            )
             if not self._objects:
                 self.logger.warning("No objects found on image.")
             # import os, psutil
             # process = psutil.Process()
-            # print('skycat obj 2',process.memory_info().rss)                
+            # print('skycat obj 2',process.memory_info().rss)
         return self._objects
 
     def get_ccd_center(self):
@@ -131,7 +158,7 @@ class SkyCatalogInterface:
         """
         skycat_obj = self.objects[index]
         ra, dec = skycat_obj.ra, skycat_obj.dec
-        return galsim.CelestialCoord(ra*galsim.degrees, dec*galsim.degrees)
+        return galsim.CelestialCoord(ra * galsim.degrees, dec * galsim.degrees)
 
     def getObj(self, index, gsparams=None, rng=None, exptime=30):
         """
@@ -157,7 +184,11 @@ class SkyCatalogInterface:
         gsobjs = skycat_obj.get_gsobject_components(gsparams)
 
         # Compute the flux or get the cached value.
-        flux = skycat_obj.get_roman_flux(self.bandpass.name, mjd=self.mjd)*self.exptime*euclidlike.collecting_area
+        flux = (
+            skycat_obj.get_roman_flux(self.bandpass.name, mjd=self.mjd)
+            * self.exptime
+            * euclidlike.collecting_area
+        )
         if np.isnan(flux):
             return None
 
@@ -171,7 +202,7 @@ class SkyCatalogInterface:
         #         gsobjs[component] = gsobj.dilate(scale)
 
         # Set up simple SED if too faint
-        if flux<40:
+        if flux < 40:
             faint = True
         if not faint:
             seds = skycat_obj.get_observer_sed_components(mjd=self.mjd)
@@ -179,13 +210,23 @@ class SkyCatalogInterface:
         gs_obj_list = []
         for component in gsobjs:
             if faint:
-                gsobjs[component] = gsobjs[component].evaluateAtWavelength(self.bandpass)
-                gs_obj_list.append(gsobjs[component]*self._trivial_sed
-                               *self.exptime*euclidlike.collecting_area)
+                gsobjs[component] = gsobjs[component].evaluateAtWavelength(
+                    self.bandpass
+                )
+                gs_obj_list.append(
+                    gsobjs[component]
+                    * self._trivial_sed
+                    * self.exptime
+                    * euclidlike.collecting_area
+                )
             else:
                 if component in seds:
-                    gs_obj_list.append(gsobjs[component]*seds[component]
-                                   *self.exptime*euclidlike.collecting_area)
+                    gs_obj_list.append(
+                        gsobjs[component]
+                        * seds[component]
+                        * self.exptime
+                        * euclidlike.collecting_area
+                    )
 
         if not gs_obj_list:
             return None
@@ -197,15 +238,17 @@ class SkyCatalogInterface:
 
         # Give the object the right flux
         gs_object.flux = flux
-        gs_object.withFlux(gs_object.flux,self.bandpass)
+        gs_object.withFlux(gs_object.flux, self.bandpass)
 
         # Get the object type
-        if (skycat_obj.object_type == 'diffsky_galaxy') | (skycat_obj.object_type == 'galaxy'):
-            gs_object.object_type = 'galaxy'
-        if skycat_obj.object_type == 'star':
-            gs_object.object_type = 'star'
-        if skycat_obj.object_type == 'snana':
-            gs_object.object_type = 'transient'
+        if (skycat_obj.object_type == "diffsky_galaxy") | (
+            skycat_obj.object_type == "galaxy"
+        ):
+            gs_object.object_type = "galaxy"
+        if skycat_obj.object_type == "star":
+            gs_object.object_type = "star"
+        if skycat_obj.object_type == "snana":
+            gs_object.object_type = "transient"
 
         return gs_object
 
@@ -214,23 +257,25 @@ class SkyCatalogLoader(InputLoader):
     """
     Class to load SkyCatalogInterface object.
     """
+
     def getKwargs(self, config, base, logger):
-        req = {'file_name': str, 'exptime' : float}
+        req = {"file_name": str, "exptime": float}
         opt = {
-               'edge_pix' : float,
-               'obj_types' : list,
-               'mjd': float,
-              }
-        kwargs, safe = galsim.config.GetAllParams(config, base, req=req,
-                                                  opt=opt)
-        wcs = galsim.config.BuildWCS(base['image'], 'wcs', base, logger=logger)
-        kwargs['wcs'] = wcs
-        kwargs['logger'] = logger
+            "edge_pix": float,
+            "obj_types": list,
+            "mjd": float,
+        }
+        kwargs, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt)
+        wcs = galsim.config.BuildWCS(base["image"], "wcs", base, logger=logger)
+        kwargs["wcs"] = wcs
+        kwargs["logger"] = logger
 
-        if 'bandpass' not in config:
-            base['bandpass'] = galsim.config.BuildBandpass(base['image'], 'bandpass', base, logger=logger)[0]
+        if "bandpass" not in config:
+            base["bandpass"] = galsim.config.BuildBandpass(
+                base["image"], "bandpass", base, logger=logger
+            )[0]
 
-        kwargs['bandpass'] = base['bandpass']
+        kwargs["bandpass"] = base["bandpass"]
         # Sky catalog object lists are created per CCD, so they are
         # not safe to reuse.
         safe = False
@@ -241,23 +286,25 @@ def SkyCatObj(config, base, ignore, gsparams, logger):
     """
     Build an object according to info in the sky catalog.
     """
-    skycat = galsim.config.GetInputObj('sky_catalog', config, base, 'SkyCatObj')
+    skycat = galsim.config.GetInputObj("sky_catalog", config, base, "SkyCatObj")
 
     # Ensure that this sky catalog matches the CCD being simulated by
     # comparing center locations on the sky.
-    world_center = base['world_center']
+    world_center = base["world_center"]
     ccd_center = skycat.get_ccd_center()
-    sep = ccd_center.distanceTo(base['world_center'])/galsim.arcsec
+    sep = ccd_center.distanceTo(base["world_center"]) / galsim.arcsec
     # Centers must agree to within at least 1 arcsec:
     if sep > 1.0:
-        message = ("skyCatalogs selection and CCD center do not agree: \n"
-                   "skycat.ccd_center: "
-                   f"{ccd_center.ra/galsim.degrees:.5f}, "
-                   f"{ccd_center.dec/galsim.degrees:.5f}\n"
-                   "world_center: "
-                   f"{world_center.ra/galsim.degrees:.5f}, "
-                   f"{world_center.dec/galsim.degrees:.5f} \n"
-                   f"Separation: {sep:.2e} arcsec")
+        message = (
+            "skyCatalogs selection and CCD center do not agree: \n"
+            "skycat.ccd_center: "
+            f"{ccd_center.ra/galsim.degrees:.5f}, "
+            f"{ccd_center.dec/galsim.degrees:.5f}\n"
+            "world_center: "
+            f"{world_center.ra/galsim.degrees:.5f}, "
+            f"{world_center.dec/galsim.degrees:.5f} \n"
+            f"Separation: {sep:.2e} arcsec"
+        )
         raise RuntimeError(message)
 
     # Setup the indexing sequence if it hasn't been specified.  The
@@ -266,24 +313,22 @@ def SkyCatObj(config, base, ignore, gsparams, logger):
     # it for them.
     galsim.config.SetDefaultIndex(config, skycat.getNObjects())
 
-    req = { 'index' : int }
-    opt = { 'num' : int }
+    req = {"index": int}
+    opt = {"num": int}
     kwargs, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt)
-    index = kwargs['index']
+    index = kwargs["index"]
 
-    rng = galsim.config.GetRNG(config, base, logger, 'SkyCatObj')
+    rng = galsim.config.GetRNG(config, base, logger, "SkyCatObj")
 
     obj = skycat.getObj(index, gsparams=gsparams, rng=rng)
-    base['object_id'] = skycat.objects[index].id
+    base["object_id"] = skycat.objects[index].id
 
     return obj, safe
 
 
 def SkyCatWorldPos(config, base, value_type):
-    """Return a value from the object part of the skyCatalog
-    """
-    skycat = galsim.config.GetInputObj('sky_catalog', config, base,
-                                       'SkyCatWorldPos')
+    """Return a value from the object part of the skyCatalog"""
+    skycat = galsim.config.GetInputObj("sky_catalog", config, base, "SkyCatWorldPos")
 
     # Setup the indexing sequence if it hasn't been specified.  The
     # normal thing with a catalog is to just use each object in order,
@@ -291,17 +336,17 @@ def SkyCatWorldPos(config, base, value_type):
     # it for them.
     galsim.config.SetDefaultIndex(config, skycat.getNObjects())
 
-    req = { 'index' : int }
-    opt = { 'num' : int }
+    req = {"index": int}
+    opt = {"num": int}
     kwargs, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt)
-    index = kwargs['index']
+    index = kwargs["index"]
 
     pos = skycat.getWorldPos(index)
     return pos, safe
 
 
-RegisterInputType('sky_catalog',
-                  SkyCatalogLoader(SkyCatalogInterface, has_nobj=True))
-RegisterObjectType('SkyCatObj', SkyCatObj, input_type='sky_catalog')
-RegisterValueType('SkyCatWorldPos', SkyCatWorldPos, [galsim.CelestialCoord],
-                  input_type='sky_catalog')
+RegisterInputType("sky_catalog", SkyCatalogLoader(SkyCatalogInterface, has_nobj=True))
+RegisterObjectType("SkyCatObj", SkyCatObj, input_type="sky_catalog")
+RegisterValueType(
+    "SkyCatWorldPos", SkyCatWorldPos, [galsim.CelestialCoord], input_type="sky_catalog"
+)

--- a/euclidlike_imsim/wcs.py
+++ b/euclidlike_imsim/wcs.py
@@ -1,34 +1,37 @@
 from astropy.time import Time
 import galsim
 import galsim.roman as roman
-from galsim.config import WCSBuilder,RegisterWCSType
+from galsim.config import WCSBuilder, RegisterWCSType
 from galsim.angle import Angle
 from galsim.celestial import CelestialCoord
+
 
 class RomanWCS(WCSBuilder):
 
     def buildWCS(self, config, base, logger):
 
-        req = { 'CCD' : int,
-                'ra'  : Angle,
-                'dec' : Angle,
-                'pa'  : Angle,
-                'mjd' : float,
-              }
-        opt = {'max_sun_angle': float,
-                'force_cvz': bool}
+        req = {
+            "CCD": int,
+            "ra": Angle,
+            "dec": Angle,
+            "pa": Angle,
+            "mjd": float,
+        }
+        opt = {"max_sun_angle": float, "force_cvz": bool}
 
         kwargs, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt)
-        if 'max_sun_angle' in kwargs:
-            roman.max_sun_angle = kwargs['max_sun_angle']
-            roman.roman_wcs.max_sun_angle = kwargs['max_sun_angle']
-        pointing = CelestialCoord(ra=kwargs['ra'], dec=kwargs['dec'])
-        wcs = roman.getWCS(world_pos        = pointing,
-                                PA          = kwargs['pa'],
-                                date        = Time(kwargs['mjd'],format='mjd').datetime,
-                                SCAs        = kwargs['CCD'],
-                                PA_is_FPA   = True
-                                )[kwargs['CCD']]
+        if "max_sun_angle" in kwargs:
+            roman.max_sun_angle = kwargs["max_sun_angle"]
+            roman.roman_wcs.max_sun_angle = kwargs["max_sun_angle"]
+        pointing = CelestialCoord(ra=kwargs["ra"], dec=kwargs["dec"])
+        wcs = roman.getWCS(
+            world_pos=pointing,
+            PA=kwargs["pa"],
+            date=Time(kwargs["mjd"], format="mjd").datetime,
+            SCAs=kwargs["CCD"],
+            PA_is_FPA=True,
+        )[kwargs["CCD"]]
         return wcs
 
-RegisterWCSType('RomanWCS', RomanWCS())
+
+RegisterWCSType("RomanWCS", RomanWCS())


### PR DESCRIPTION
This PR replaces every occurrence of `SCA` or `sca` with `ccd` for our euclidlike image simulation. It is still using `getPSF` or `getWCS` from `galsim.roman` so the function parameter name is still `SCA` but the value passed in as arguments are `CCD`.