### PR TITLE
Add script to generate the EuclidLike pupil plane

### DIFF
--- a/scripts/make_euclidlike_pupil_plane.py
+++ b/scripts/make_euclidlike_pupil_plane.py
@@ -40,10 +40,6 @@ sp3_x_pos = 70  # [mm]
 sp3_y_pos = -330  # [mm]
 
 
-def round_even(n):
-    return int(2 * np.round(n / 2))
-
-
 def make_EuclidLike_pupil_plane(N_pix=2048, do_filter=True, N_filter=3):
     # Build pupil plane
     pupil_plane = np.ones((N_pix, N_pix))


### PR DESCRIPTION
Issue #62

This script create the Euclid-Like pupil plane.
By default it will check if galsim euclidlike is installed and if it is, it will create the pupil_plane in euclidlike.data directory. This is the intended usage. There is also the option to provide manually the output but if it is different from the default, galsim euclidlike will not found it.