### PR TITLE
Add skyCat output

### DIFF
--- a/config/was.yaml
+++ b/config/was.yaml
@@ -14,6 +14,13 @@ modules:
     # the globals dict it uses when evaluating Eval items, so we can tell it to import it here.
     - datetime
 
+# Variables used to request LSST flux in the output catalog
+eval_variables:
+    frubin_area:
+        type : Eval
+        str : '3.14159 * (418**2 - 255**2)'
+    frubin_exptime: 30
+
 # Define some other information about the images
 image:
 
@@ -159,3 +166,14 @@ output:
             flux: "@flux"
             mag: "@mag"
             obj_type: "@object_type"
+            gal_disk_hlr: { type: SkyCatValue, field: diskHalfLightRadiusArcsec }
+            gal_redshift: { type: SkyCatValue, field: redshift }
+            sn_host_id: { type: SkyCatValue, field: host_id }
+            lsst_flux_r:
+                type : Eval
+                fflux : { type: SkyCatValue, field: lsst_flux_r }
+                str : 'flux * rubin_exptime * rubin_area'
+            lsst_mag_r:
+                type : Eval
+                fflux : { type: SkyCatValue, field: lsst_flux_r }
+                str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_r) + 28.36"

--- a/euclidlike_imsim/skycat.py
+++ b/euclidlike_imsim/skycat.py
@@ -177,6 +177,29 @@ class SkyCatalogInterface:
         return galsim.CelestialCoord(ra * galsim.degrees, dec * galsim.degrees)
 
     def getFlux(self, index, filter=None, mjd=None, exptime=None):
+        """
+        Return the flux associated to an object.
+
+        Parameters
+        ----------
+        index : int
+            Index of the object in the self.objects catalog.
+        filter : str, optional
+            Name of the filter for which the flux is computed. If None, use the
+            filter provided during initialization. [Default: None]
+        mjd : float, optional
+            Date of the observation in MJD format. If None, use the
+            mjd provided during initialization. [Default: None]
+        exptime : int or float, optional
+            Exposure time of the observation. If None, use the
+            exptime provided during initialization. [Default: None]
+
+        Returns
+        -------
+        flux
+            Computer flux at the given date for the requested exposure time and
+            filter.
+        """
 
         if filter is None:
             filter = self.bandpass.name
@@ -208,6 +231,21 @@ class SkyCatalogInterface:
         return flux
 
     def getValue(self, index, field):
+        """
+        Return a skyCatalog value for the an object.
+
+        Parameters
+        ----------
+        index : int
+            Index of the object in the self.objects catalog.
+        field : str
+            Name of the field for which you want the value.
+
+        Returns
+        -------
+        int or float or str or None
+            The value associated to the field or None if the field do not exist.
+        """
 
         skycat_obj = self.objects[index]
 
@@ -404,6 +442,8 @@ def SkyCatWorldPos(config, base, value_type):
 
 
 def SkyCatValue(config, base, value_type):
+    """Return a value from the object part of the skyCatalog
+    """
 
     skycat = galsim.config.GetInputObj("sky_catalog", config, base, "SkyCatValue")
 


### PR DESCRIPTION
Add the possibility to request `skyCatalog` entries to the output truth catalog.
For that we introduce a new `ValueType`: `SkyCatValue`. The use is straightforward:
```yaml
output:
    truth:
        columns:
            gal_disk_hlr: { type: SkyCatValue, field: diskHalfLightRadiusArcsec }
            gal_redshift: { type: SkyCatValue, field: redshift }
```

This PR also implement some modifications to the `getFlux` method in anticipation of a future PR to handle photometry error. It makes no difference to the user in terms of output or computational time.