### PR TITLE
Small documentation update for flux units in imsim.

### DIFF
--- a/euclidlike_imsim/stamp.py
+++ b/euclidlike_imsim/stamp.py
@@ -16,7 +16,7 @@ class Euclidlike_stamp(StampBuilder):
 
     It uses the regular Basic functions for most things.
     It specializes the quickSkip, buildProfile, and draw methods.
-    Note that the flux used throughout this class does is not equal to the flux from
+    Note that the flux used throughout this class is not equal to the flux from
     the truth catalogs, but rather the true flux times the exposure time and collecting area.
     """
     _trivial_sed = galsim.SED(

--- a/euclidlike_imsim/stamp.py
+++ b/euclidlike_imsim/stamp.py
@@ -16,6 +16,8 @@ class Euclidlike_stamp(StampBuilder):
 
     It uses the regular Basic functions for most things.
     It specializes the quickSkip, buildProfile, and draw methods.
+    Note that the flux used throughout this class does is not equal to the flux from
+    the truth catalogs, but rather the true flux times the exposure time and collecting area.
     """
     _trivial_sed = galsim.SED(
         galsim.LookupTable(


### PR DESCRIPTION
Added a sentence in `stamp.py` in `euclidlike_imsim` clarifying that the flux used in this class is not the flux from the truth catalogs, but rather the true flux times the collecting area and exposure time.