### PR TITLE
Update header

### DIFF
--- a/config/was.yaml
+++ b/config/was.yaml
@@ -210,6 +210,7 @@ output:
             gal_shear2: { type: SkyCatValue, field: shear2 }
             gal_convergence: { type: SkyCatValue, field: convergence }
             sn_host_id: { type: SkyCatValue, field: host_id }
+            # The LSST mag_AB zero_point are computed from the LSST bandpasses included with GalSim.
             lsst_flux_u: { type: SkyCatValue, field: lsst_flux_u }
             lsst_mag_u:
                 type : Eval

--- a/config/was.yaml
+++ b/config/was.yaml
@@ -14,12 +14,11 @@ modules:
     # the globals dict it uses when evaluating Eval items, so we can tell it to import it here.
     - datetime
 
-# Variables used to request LSST flux in the output catalog
+# We evaluate the Euclid zeropoint here to save time in the output catalog.
 eval_variables:
-    frubin_area:
+    feuclid_AB_ZP: 
         type : Eval
-        str : '3.14159 * (418**2 - 255**2)'
-    frubin_exptime: 30
+        str : 'euclidlike.getBandpasses()["VIS"].zeropoint'
 
 # Define some other information about the images
 image:
@@ -77,6 +76,10 @@ image:
     filter: { type: ObSeqData, field: filter }
     exptime: { type: ObSeqData, field: exptime }
 
+    # This is not a required field for the processing but this is the easiest way to propagate
+    # this information to the output images.
+    obs_id: { type: ObSeqData, field: obs_id }
+
     # Photon shooting is way faster for chromatic objects than fft, especially when most of them
     # are fairly faint.  The cross-over point for achromatic objects is generally of order
     # flux=1.e6 or so (depending on the profile).  Most of our objects here are much fainter than
@@ -126,7 +129,7 @@ input:
         file_name: /path/to/skyCatalog.yaml
         edge_pix: 512
         mjd: { type: ObSeqData, field: mjd }
-        exptime: { type: ObSeqData, field: exptime }          
+        exptime: { type: ObSeqData, field: exptime }
         obj_types: ['diffsky_galaxy','star','snana']
 
 output:
@@ -135,51 +138,56 @@ output:
     dir: /path/to/output/images
     file_name:
         type: FormattedStr
-        format: "Euclidlike_WAS_truth_%s_%i_%i.fits.gz"
+        format: "EUC_ELSIM_SWL_DET-%s-%s-1-%s__%sZ.fits"
         items:
-            - { type: ObSeqData, field: filter }
-            - { type: ObSeqData, field: visit }
-            - '@image.CCD'
+            - { type: Eval, iobsId: { type: ObSeqData, field: obs_id }, str: 'str(obsId).zfill(6)' }
+            - { type: Eval, idither: { type: ObSeqData, field: dither_id }, str: 'str(dither).zfill(2)' }
+            - { type: Eval, sccd: '@image.CCD', str: 'ccd.zfill(7)' }
+            - { type: Eval, sdate: { type: ObSeqData, field: date }, str: 'datetime.datetime.fromisoformat(date).strftime("%Y%m%dT%H%M%S.%f")' }
 
     noise_image:
         dir: /path/to/output/noise_images
         file_name:
             type: FormattedStr
-            format: "Euclidlike_WAS_truth_%s_%i_%i.noise.fits.gz"
+            format: "EUC_ELSIM_SWL_VAR-%s-%s-1-%s__%sZ.fits"
             items:
-                - { type: ObSeqData, field: filter }
-                - { type: ObSeqData, field: visit }
-                - '@image.CCD'
+                - { type: Eval, iobsId: { type: ObSeqData, field: obs_id }, str: 'str(obsId).zfill(6)' }
+                - { type: Eval, idither: { type: ObSeqData, field: dither_id }, str: 'str(dither).zfill(2)' }
+                - { type: Eval, sccd: '@image.CCD', str: 'ccd.zfill(7)' }
+                - { type: Eval, sdate: { type: ObSeqData, field: date }, str: 'datetime.datetime.fromisoformat(date).strftime("%Y%m%dT%H%M%S.%f")' }
 
     sky_image:
         dir: /path/to/output/sky_images
         file_name:
             type: FormattedStr
-            format: "Euclidlike_WAS_truth_%s_%i_%i.sky.fits.gz"
+            format: "EUC_ELSIM_SWL_BKG-%s-%s-1-%s__%sZ.fits"
             items:
-                - { type: ObSeqData, field: filter }
-                - { type: ObSeqData, field: visit }
-                - '@image.CCD'
+                - { type: Eval, iobsId: { type: ObSeqData, field: obs_id }, str: 'str(obsId).zfill(6)' }
+                - { type: Eval, idither: { type: ObSeqData, field: dither_id }, str: 'str(dither).zfill(2)' }
+                - { type: Eval, sccd: '@image.CCD', str: 'ccd.zfill(7)' }
+                - { type: Eval, sdate: { type: ObSeqData, field: date }, str: 'datetime.datetime.fromisoformat(date).strftime("%Y%m%dT%H%M%S.%f")' }
 
     weight_image:
         dir: /path/to/output/weight_images
         file_name:
             type: FormattedStr
-            format: "Euclidlike_WAS_truth_%s_%i_%i.weight.fits.gz"
+            format: "EUC_ELSIM_SWL_WGT-%s-%s-1-%s__%sZ.fits"
             items:
-                - { type: ObSeqData, field: filter }
-                - { type: ObSeqData, field: visit }
-                - '@image.CCD'
+                - { type: Eval, iobsId: { type: ObSeqData, field: obs_id }, str: 'str(obsId).zfill(6)' }
+                - { type: Eval, idither: { type: ObSeqData, field: dither_id }, str: 'str(dither).zfill(2)' }
+                - { type: Eval, sccd: '@image.CCD', str: 'ccd.zfill(7)' }
+                - { type: Eval, sdate: { type: ObSeqData, field: date }, str: 'datetime.datetime.fromisoformat(date).strftime("%Y%m%dT%H%M%S.%f")' }
 
     truth:
         dir: /path/to/output/truth
         file_name:
             type: FormattedStr
-            format: "Euclidlike_WAS_index_%s_%i_%i.txt"
+            format: "EUC_ELSIM_SWL_WGT-%s-%s-1-%s__%sZ.txt"
             items:
-                - { type: ObSeqData, field: filter }
-                - { type: ObSeqData, field: visit }
-                - '@image.CCD'
+                - { type: Eval, iobsId: { type: ObSeqData, field: obs_id }, str: 'str(obsId).zfill(6)' }
+                - { type: Eval, idither: { type: ObSeqData, field: dither_id }, str: 'str(dither).zfill(2)' }
+                - { type: Eval, sccd: '@image.CCD', str: 'ccd.zfill(7)' }
+                - { type: Eval, sdate: { type: ObSeqData, field: date }, str: 'datetime.datetime.fromisoformat(date).strftime("%Y%m%dT%H%M%S.%f")' }
         columns:
             object_id: "@object_id"
             ra: "$sky_pos.ra.deg"
@@ -189,15 +197,40 @@ output:
             realized_flux: "@realized_flux"
             flux: "@flux"
             mag: "@mag"
+            mag_AB: { type: Eval, str: '-2.5 * np.log10(@flux/@image.exptime/euclidlike.collecting_area) + euclid_AB_ZP' }
             obj_type: "@object_type"
-            gal_disk_hlr: { type: SkyCatValue, field: diskHalfLightRadiusArcsec }
             gal_redshift: { type: SkyCatValue, field: redshift }
+            gal_disk_hlr: { type: SkyCatValue, field: diskHalfLightRadiusArcsec }
+            gal_disk_e1: { type: SkyCatValue, field: diskEllipticity1 }
+            gal_disk_e2: { type: SkyCatValue, field: diskEllipticity2 }
+            gal_bulge_hlr: { type: SkyCatValue, field: spheroidHalfLightRadiusArcsec }
+            gal_bulge_e1: { type: SkyCatValue, field: spheroidEllipticity1 }
+            gal_bulge_e2: { type: SkyCatValue, field: spheroidEllipticity2 }
+            gal_shear1: { type: SkyCatValue, field: shear1 }
+            gal_shear2: { type: SkyCatValue, field: shear2 }
+            gal_convergence: { type: SkyCatValue, field: convergence }
             sn_host_id: { type: SkyCatValue, field: host_id }
-            lsst_flux_r:
+            lsst_flux_u: { type: SkyCatValue, field: lsst_flux_u }
+            lsst_mag_u:
                 type : Eval
-                fflux : { type: SkyCatValue, field: lsst_flux_r }
-                str : 'flux * rubin_exptime * rubin_area'
+                str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_u) + 12.628"
+            lsst_flux_g: { type: SkyCatValue, field: lsst_flux_g }
+            lsst_mag_g:
+                type : Eval
+                str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_g) + 14.486"
+            lsst_flux_r: { type: SkyCatValue, field: lsst_flux_r }
             lsst_mag_r:
                 type : Eval
-                fflux : { type: SkyCatValue, field: lsst_flux_r }
-                str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_r) + 28.36"
+                str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_r) + 14.325"
+            lsst_flux_i: { type: SkyCatValue, field: lsst_flux_i }
+            lsst_mag_i:
+                type : Eval
+                str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_i) + 13.999"
+            lsst_flux_z: { type: SkyCatValue, field: lsst_flux_z }
+            lsst_mag_z:
+                type : Eval
+                str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_z) + 13.613"
+            lsst_flux_y: { type: SkyCatValue, field: lsst_flux_y }
+            lsst_mag_y:
+                type : Eval
+                str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_y) + 12.785"

--- a/config/was.yaml
+++ b/config/was.yaml
@@ -149,7 +149,7 @@ output:
         dir: /path/to/output/noise_images
         file_name:
             type: FormattedStr
-            format: "EUC_ELSIM_SWL_VAR-%s-%s-1-%s__%sZ.fits"
+            format: "EUC_ELSIM_SWL_NOISE-%s-%s-1-%s__%sZ.fits"
             items:
                 - { type: Eval, iobsId: { type: ObSeqData, field: obs_id }, str: 'str(obsId).zfill(6)' }
                 - { type: Eval, idither: { type: ObSeqData, field: dither_id }, str: 'str(dither).zfill(2)' }
@@ -182,7 +182,7 @@ output:
         dir: /path/to/output/truth
         file_name:
             type: FormattedStr
-            format: "EUC_ELSIM_SWL_WGT-%s-%s-1-%s__%sZ.txt"
+            format: "EUC_ELSIM_SWL_CAT-%s-%s-1-%s__%sZ.txt"
             items:
                 - { type: Eval, iobsId: { type: ObSeqData, field: obs_id }, str: 'str(obsId).zfill(6)' }
                 - { type: Eval, idither: { type: ObSeqData, field: dither_id }, str: 'str(dither).zfill(2)' }

--- a/euclidlike/instrument_params.py
+++ b/euclidlike/instrument_params.py
@@ -21,7 +21,7 @@ nisp_exptime_eff = 87.2  # s (effective time NISP imaging exposures) (This is th
 short_exptime_vis = 95 # s (for the shorter exposures with VIS taken in parallel with NISP imaging)
 short_exptime_vis_eff = 89.52  # s (effective time VIS imaging exposures) (This is the one to use for flux computation)
 read_noise = 4.4  # e-, https://www.euclid-ec.org/public/mission/vis/
-saturation = 200000 # e-, from https://www.euclid-ec.org/public/mission/vis/
+saturation = 65535  # ADU, https://arxiv.org/pdf/2503.15303 Sect. 3.3 (max for uint32)
 n_dithers = 4
 n_ccd = 36
 n_ccd_row = 6
@@ -124,6 +124,9 @@ nisp_bands = ['NISP_Y', 'NISP_J', 'NISP_H']
 vis_blue_limit = 540
 vis_red_limit = 910
 
+# Coadd info
+coadd_zeropoint = 23.9  # Euclid zero-point in AB mag, used in all bands
+
 # Items to potentially do later; part of the galsim.roman setup that currently has no correspondence
 # here.
 #   dark_current
@@ -138,5 +141,4 @@ vis_red_limit = 910
 # separately, so there is no parameter for setting them (e.g. a Gaussian sigma) in
 # this module.  However, pointing errors / jitter are quantified in the VIS paper.
 #
-# The impact of the dichroic and of charge transfer inefficiency are not included.  Same for
-# saturation (200000 e-).
+# The impact of the dichroic and of charge transfer inefficiency are not included.

--- a/euclidlike/instrument_params.py
+++ b/euclidlike/instrument_params.py
@@ -21,6 +21,7 @@ nisp_exptime_eff = 87.2  # s (effective time NISP imaging exposures) (This is th
 short_exptime_vis = 95 # s (for the shorter exposures with VIS taken in parallel with NISP imaging)
 short_exptime_vis_eff = 89.52  # s (effective time VIS imaging exposures) (This is the one to use for flux computation)
 read_noise = 4.4  # e-, https://www.euclid-ec.org/public/mission/vis/
+# The reported value for the saturation in Q1 headers is closer to 44000 ADU
 saturation = 65535  # ADU, https://arxiv.org/pdf/2503.15303 Sect. 3.3 (max for uint32)
 n_dithers = 4
 n_ccd = 36

--- a/euclidlike/instrument_params.py
+++ b/euclidlike/instrument_params.py
@@ -126,7 +126,7 @@ vis_blue_limit = 540
 vis_red_limit = 910
 
 # Coadd info
-coadd_zeropoint = 23.9  # Euclid zero-point in AB mag, used in all bands
+coadd_zeropoint = 23.9  # Euclid zero-point in AB mag, used in all bands. Ref: http://st-dm.pages.euclid-sgs.uk/data-product-doc/dmq1/merdpd/merphotometrycookbook.html
 
 # Items to potentially do later; part of the galsim.roman setup that currently has no correspondence
 # here.

--- a/euclidlike_imsim/noise.py
+++ b/euclidlike_imsim/noise.py
@@ -151,6 +151,7 @@ class NoiseImageBuilder(galsim.config.ExtraOutputBuilder):
             "stamp_xsize",
             "stamp_ysize",
             "nobjects",
+            "obs_id",
         ]
         params = galsim.config.GetAllParams(
             base["image"], base, req=req, opt=opt, ignore=ignore+extra_ignore,

--- a/euclidlike_imsim/obseq.py
+++ b/euclidlike_imsim/obseq.py
@@ -60,11 +60,13 @@ class ObSeqDataLoader(object):
             _ob = {}
             _ob["visit"] = self.visit
             _ob["ccd"] = self.ccd
+            _ob["obs_id"] = ob.loc[obs_kind]["obs_id"]
+            _ob["dither_id"] = ob.loc[obs_kind]["dither_id"]
             _ob["ra"] = ob.loc[obs_kind]["ra"] * galsim.degrees
             _ob["dec"] = ob.loc[obs_kind]["dec"] * galsim.degrees
             _ob["pa"] = ob.loc[obs_kind]["pa"] * galsim.degrees
             _ob["saa"] = ob.loc[obs_kind]["saa"] * galsim.degrees
-            _ob["date"] = Time(ob.loc[obs_kind]["date"], format="mjd").datetime
+            _ob["date"] = str(Time(ob.loc[obs_kind]["date"], format="mjd").datetime)
             _ob["mjd"] = ob.loc[obs_kind]["date"]
             _ob["filter"] = ob.loc[obs_kind]["filter"]
             _ob["exptime"] = ob.loc[obs_kind]["exptime"]


### PR DESCRIPTION
Update the header keywords to follow the naming convention from Euclid. The output file names has also been updated to follow the Euclid naming with some modifications:
The format for the VIS single exposure is: `EUC_VIS_SWL_DET-[ObsId]-[Dither]-[exposure]-0000000__[YYYYMMDDThhmmss.s]Z.fits` which has been changed to: `EUC_ELSIM_SWL_DET-[ObsId]-[Dither]-[exposure]-[CCD_number]__[YYYYMMDDThhmmss.s]Z.fits` where `ELSIM` stand for: "Euclid-Like Simulation"

The ref for the header keywords and file names: http://st-dm.pages.euclid-sgs.uk/data-product-doc/dmq1/visdpd/dpcards/vis_calibratedquadframe.html#viscalibratedquadframe

This should address: #113 #49 