### PR TITLE
Add support for photometry error

### DIFF
--- a/config/was.yaml
+++ b/config/was.yaml
@@ -16,9 +16,18 @@ modules:
 
 # We evaluate the Euclid zeropoint here to save time in the output catalog.
 eval_variables:
-    feuclid_AB_ZP: 
+    feuclid_AB_ZP_VIS: 
         type : Eval
         str : 'euclidlike.getBandpasses()["VIS"].zeropoint'
+    feuclid_AB_ZP_Y: 
+        type : Eval
+        str : 'euclidlike.getBandpasses()["NISP_Y"].zeropoint'
+    feuclid_AB_ZP_J: 
+        type : Eval
+        str : 'euclidlike.getBandpasses()["NISP_J"].zeropoint'
+    feuclid_AB_ZP_H: 
+        type : Eval
+        str : 'euclidlike.getBandpasses()["NISP_H"].zeropoint'
 
 # Define some other information about the images
 image:
@@ -131,6 +140,28 @@ input:
         mjd: { type: ObSeqData, field: mjd }
         exptime: { type: ObSeqData, field: exptime }
         obj_types: ['diffsky_galaxy','star','snana']
+    photerr_config:
+        m5:
+            VIS: 27.0
+            Y: 24.46
+            J: 24.56
+            H: 24.42
+        theta:
+            VIS: 0.203
+            Y: 0.475
+            J: 0.504
+            H: 0.542
+        extendedType:
+            galaxy: 'auto'
+            star: 'point'
+            transient: 'point'
+        gain:
+            VIS:
+                type: Eval
+                str: 'euclidlike.gain'
+            Y: 1.
+            J: 1.
+            H: 1.
 
 output:
 
@@ -194,45 +225,115 @@ output:
             dec: "$sky_pos.dec.deg"
             x: "$image_pos.x"
             y: "$image_pos.y"
-            realized_flux: "@realized_flux"
-            flux: "@flux"
-            flux_bulge: { type: SkyCatValue, field: flux, obs_kind: '@input.obseq_data.obs_kind', component: 'bulge' }
-            mag: "@mag"
-            mag_AB: { type: Eval, str: '-2.5 * np.log10(@flux/@image.exptime/euclidlike.collecting_area) + euclid_AB_ZP' }
+            realized_flux_VIS: "@realized_flux"
+            flux_VIS: "@flux"
+            flux_bulge_VIS: { type: SkyCatValue, field: flux, obs_kind: '@input.obseq_data.obs_kind', component: 'bulge' }
+            flux_disk_VIS: { type: SkyCatValue, field: flux, obs_kind: '@input.obseq_data.obs_kind', component: 'disk' }
+            flux_knots_VIS: { type: SkyCatValue, field: flux, obs_kind: '@input.obseq_data.obs_kind', component: 'knots' }
+            bulge2total_VIS:
+                type: Eval
+                str: '@output.truth.columns.flux_bulge_VIS / @output.truth.columns.flux_VIS'
+            mag_VIS: "@mag"
             obj_type: "@object_type"
             gal_redshift: { type: SkyCatValue, field: redshift }
             gal_disk_hlr: { type: SkyCatValue, field: diskHalfLightRadiusArcsec }
-            gal_disk_e1: { type: SkyCatValue, field: diskEllipticity1 }
-            gal_disk_e2: { type: SkyCatValue, field: diskEllipticity2 }
+            gal_disk_g1: { type: SkyCatValue, field: diskEllipticity1 }
+            gal_disk_g2: { type: SkyCatValue, field: diskEllipticity2 }
             gal_bulge_hlr: { type: SkyCatValue, field: spheroidHalfLightRadiusArcsec }
-            gal_bulge_e1: { type: SkyCatValue, field: spheroidEllipticity1 }
-            gal_bulge_e2: { type: SkyCatValue, field: spheroidEllipticity2 }
+            gal_bulge_g1: { type: SkyCatValue, field: spheroidEllipticity1 }
+            gal_bulge_g2: { type: SkyCatValue, field: spheroidEllipticity2 }
             gal_shear1: { type: SkyCatValue, field: shear1 }
             gal_shear2: { type: SkyCatValue, field: shear2 }
             gal_convergence: { type: SkyCatValue, field: convergence }
             sn_host_id: { type: SkyCatValue, field: host_id }
             # The LSST mag_AB zero_point are computed from the LSST bandpasses included with GalSim.
             lsst_flux_u: { type: SkyCatValue, field: lsst_flux_u }
-            lsst_mag_u:
+            lsst_mag_AB_u:
                 type : Eval
                 str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_u) + 12.628"
             lsst_flux_g: { type: SkyCatValue, field: lsst_flux_g }
-            lsst_mag_g:
+            lsst_mag_AB_g:
                 type : Eval
                 str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_g) + 14.486"
             lsst_flux_r: { type: SkyCatValue, field: lsst_flux_r }
-            lsst_mag_r:
+            lsst_mag_AB_r:
                 type : Eval
                 str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_r) + 14.325"
             lsst_flux_i: { type: SkyCatValue, field: lsst_flux_i }
-            lsst_mag_i:
+            lsst_mag_AB_i:
                 type : Eval
                 str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_i) + 13.999"
             lsst_flux_z: { type: SkyCatValue, field: lsst_flux_z }
-            lsst_mag_z:
+            lsst_mag_AB_z:
                 type : Eval
                 str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_z) + 13.613"
             lsst_flux_y: { type: SkyCatValue, field: lsst_flux_y }
-            lsst_mag_y:
+            lsst_mag_AB_y:
                 type : Eval
                 str : "-2.5 * np.log10(@output.truth.columns.lsst_flux_y) + 12.785"
+            mag_AB_VIS:
+                type: Eval
+                str: '-2.5 * np.log10(@flux/@image.exptime/euclidlike.collecting_area) + euclid_AB_ZP_VIS'
+            # Euclid mag_err are computed using the PhotErr package.
+            # Euclid Near-IR quantities are based on several approximation and provided as an indication. But
+            # they follow the Euclid survey strategy.
+            mag_err_VIS:
+                type: PhotErr
+                mag: "@output.truth.columns.mag_AB_VIS"
+                obs_kind: "@input.obseq_data.obs_kind"
+                g1_disk: "@output.truth.columns.gal_disk_g1"
+                g2_disk: "@output.truth.columns.gal_disk_g2"
+                hlr_disk: "@output.truth.columns.gal_disk_hlr"
+                g1_bulge: "@output.truth.columns.gal_bulge_g1"
+                g2_bulge: "@output.truth.columns.gal_bulge_g2"
+                hlr_bulge: "@output.truth.columns.gal_bulge_hlr"
+                BTT: "@output.truth.columns.bulge2total_VIS"
+                obj_type: "@output.truth.columns.obj_type"
+            flux_Y: { type: SkyCatValue, field: flux, obs_kind: "NISP_Y"}
+            mag_AB_Y:
+                type: Eval
+                str: '-2.5 * np.log10(@output.truth.columns.flux_Y/euclidlike.nisp_exptime_eff/euclidlike.collecting_area) + euclid_AB_ZP_Y'
+            mag_err_Y:
+                type: PhotErr
+                mag: "@output.truth.columns.mag_AB_Y"
+                obs_kind: "NISP_Y"
+                g1_disk: "@output.truth.columns.gal_disk_g1"
+                g2_disk: "@output.truth.columns.gal_disk_g2"
+                hlr_disk: "@output.truth.columns.gal_disk_hlr"
+                g1_bulge: "@output.truth.columns.gal_bulge_g1"
+                g2_bulge: "@output.truth.columns.gal_bulge_g2"
+                hlr_bulge: "@output.truth.columns.gal_bulge_hlr"
+                BTT: "@output.truth.columns.bulge2total_VIS"
+                obj_type: "@output.truth.columns.obj_type"
+            flux_J: { type: SkyCatValue, field: flux, obs_kind: "NISP_J"}
+            mag_AB_J:
+                type: Eval
+                str: '-2.5 * np.log10(@output.truth.columns.flux_J/euclidlike.nisp_exptime_eff/euclidlike.collecting_area) + euclid_AB_ZP_J'
+            mag_err_J:
+                type: PhotErr
+                mag: "@output.truth.columns.mag_AB_J"
+                obs_kind: "NISP_J"
+                g1_disk: "@output.truth.columns.gal_disk_g1"
+                g2_disk: "@output.truth.columns.gal_disk_g2"
+                hlr_disk: "@output.truth.columns.gal_disk_hlr"
+                g1_bulge: "@output.truth.columns.gal_bulge_g1"
+                g2_bulge: "@output.truth.columns.gal_bulge_g2"
+                hlr_bulge: "@output.truth.columns.gal_bulge_hlr"
+                BTT: "@output.truth.columns.bulge2total_VIS"
+                obj_type: "@output.truth.columns.obj_type"
+            flux_H: { type: SkyCatValue, field: flux, obs_kind: "NISP_H"}
+            mag_AB_H:
+                type: Eval
+                str: '-2.5 * np.log10(@output.truth.columns.flux_H/euclidlike.nisp_exptime_eff/euclidlike.collecting_area) + euclid_AB_ZP_H'
+            mag_err_H:
+                type: PhotErr
+                mag: "@output.truth.columns.mag_AB_H"
+                obs_kind: "NISP_H"
+                g1_disk: "@output.truth.columns.gal_disk_g1"
+                g2_disk: "@output.truth.columns.gal_disk_g2"
+                hlr_disk: "@output.truth.columns.gal_disk_hlr"
+                g1_bulge: "@output.truth.columns.gal_bulge_g1"
+                g2_bulge: "@output.truth.columns.gal_bulge_g2"
+                hlr_bulge: "@output.truth.columns.gal_bulge_hlr"
+                BTT: "@output.truth.columns.bulge2total_VIS"
+                obj_type: "@output.truth.columns.obj_type"

--- a/euclidlike_imsim/__init__.py
+++ b/euclidlike_imsim/__init__.py
@@ -12,7 +12,9 @@ from .wcs import *
 from .skycat import *
 from .photonOps import *
 from .bandpass import *
+from .photometry_error import *
 
 # from .detector_physics import *
 from ._version import __version__, __version_info__
+
 version = __version__

--- a/euclidlike_imsim/photometry_error.py
+++ b/euclidlike_imsim/photometry_error.py
@@ -100,7 +100,7 @@ def get_minor_major_axis(hlr, g1, g2):
     Returns
     -------
     a : float
-        Major axis.
+        Major axis (same units as input hlr).
     b : float
         Minor axis.
     """

--- a/euclidlike_imsim/photometry_error.py
+++ b/euclidlike_imsim/photometry_error.py
@@ -102,7 +102,7 @@ def get_minor_major_axis(hlr, g1, g2):
     a : float
         Major axis (same units as input hlr).
     b : float
-        Minor axis.
+        Minor axis (same units as input hlr).
     """
 
     g = np.hypot(g1, g2)

--- a/euclidlike_imsim/photometry_error.py
+++ b/euclidlike_imsim/photometry_error.py
@@ -1,0 +1,362 @@
+from email.mime import base
+
+import numpy as np
+import galsim
+from galsim.config import RegisterValueType, InputLoader, RegisterInputType
+from galsim.errors import GalSimConfigError
+from photerr import EuclidWideErrorModel
+
+
+def get_euclid_band(obs_kind):
+    """
+    Get the Euclid band from the obs_kind.
+
+    Parameters
+    ----------
+    obs_kind : str
+        The obs_kind
+
+    Returns
+    -------
+    band : str
+        The Euclid band corresponding to the obs_kind. In the format PhotErr expects.
+    """
+    if obs_kind == "VIS_LONG" or obs_kind == "VIS_SHORT":
+        band = "VIS"
+    elif obs_kind == "NISP_Y":
+        band = "Y"
+    elif obs_kind == "NISP_J":
+        band = "J"
+    elif obs_kind == "NISP_H":
+        band = "H"
+    else:
+        raise ValueError(f"Invalid obs_kind: {obs_kind}")
+    return band
+
+
+def get_effective_g_and_hlr(
+    hlr_bulge,
+    hlr_disk,
+    g1_bulge,
+    g2_bulge,
+    g1_disk,
+    g2_disk,
+    BTT,
+):
+    """
+    Calculate the effective ellipticity for a bulge+disk galaxy.
+
+    Parameters
+    ----------
+    hlr_bulge : float
+        Half-light radius of the bulge component.
+    hlr_disk : float
+        Half-light radius of the disk component.
+    g1_bulge : float
+        First component of the ellipticity of the bulge component.
+    g2_bulge : float
+        Second component of the ellipticity of the bulge component.
+    g1_disk : float
+        First component of the ellipticity of the disk component.
+    g2_disk : float
+        Second component of the ellipticity of the disk component.
+    BTT : float
+        Bulge-to-total ratio.
+
+    Returns
+    -------
+    g1_eff : float
+        First component of the effective ellipticity.
+    g2_eff : float
+        Second component of the effective ellipticity.
+    r_eff : float
+        Effective half-light radius.
+    """
+    g_bulge = g1_bulge + 1j * g2_bulge
+    g_disk = g1_disk + 1j * g2_disk
+
+    w_bulge = BTT * hlr_bulge**2
+    w_disk = (1.0 - BTT) * hlr_disk**2
+
+    geff = (w_bulge * g_bulge + w_disk * g_disk) / (w_bulge + w_disk)
+    r_eff = np.sqrt(BTT * hlr_bulge**2 + (1.0 - BTT) * hlr_disk**2)
+
+    return geff.real, geff.imag, r_eff
+
+
+def get_minor_major_axis(hlr, g1, g2):
+    """
+    Calculate the minor and major axes of a galaxy.
+
+    Parameters
+    ----------
+    hlr : float
+        Half-light radius.
+    g1 : float
+        First component of the ellipticity.
+    g2 : float
+        Second component of the ellipticity.
+
+    Returns
+    -------
+    a : float
+        Major axis.
+    b : float
+        Minor axis.
+    """
+
+    g = np.hypot(g1, g2)
+
+    q = (1 - g) / (1 + g)
+
+    a = hlr / np.sqrt(q)
+    b = hlr * np.sqrt(q)
+
+    return a, b
+
+
+def prepare_inputs(
+    minor_, major_, g1_, g2_, hlr_, g1_disk_, g2_disk_, hlr_disk_, g1_bulge_, g2_bulge_, hlr_bulge_, BTT_
+):
+    """
+    Prepare the inputs for the photometric error calculation.
+
+    Parameters
+    ----------
+    minor_ : float or None
+        Minor axis.
+    major_ : float or None
+        Major axis.
+    g1_ : float or None
+        First component of the ellipticity.
+    g2_ : float or None
+        Second component of the ellipticity.
+    hlr_ : float or None
+        Half-light radius.
+    g1_disk_ : float or None
+        First component of the ellipticity of the disk component.
+    g2_disk_ : float or None
+        Second component of the ellipticity of the disk component.
+    hlr_disk_ : float or None
+        Half-light radius of the disk component.
+    g1_bulge_ : float or None
+        First component of the ellipticity of the bulge component.
+    g2_bulge_ : float or None
+        Second component of the ellipticity of the bulge component.
+    hlr_bulge_ : float or None
+        Half-light radius of the bulge component.
+    BTT_ : float or None
+        Bulge-to-total ratio.
+    """
+
+    check = [
+        (np.isnan(minor_)),
+        (np.isnan(major_)),
+        (np.isnan(g1_)),
+        (np.isnan(g2_)),
+        (np.isnan(hlr_)),
+        (np.isnan(g1_disk_)),
+        (np.isnan(g2_disk_)),
+        (np.isnan(hlr_disk_)),
+        (np.isnan(g1_bulge_)),
+        (np.isnan(g2_bulge_)),
+        (np.isnan(hlr_bulge_)),
+        (np.isnan(BTT_)),
+    ]
+    if any(check):
+        # This should handle the case where we get this for let's say stars and those quantities do not exist in the catalogue
+        return None, None
+
+    # check minor / major
+    check = [(minor_ is None), (major_ is None)]
+    if not any(check) and all(check):
+        raise ValueError("Both minor and major axes must be provided or both must be None.")
+    if minor_ is not None:
+        minor = np.array([minor_])
+        major = np.array([major_])
+        return minor, major
+
+    # check g1 / g2 / hlr
+    check = [(g1_ is None), (g2_ is None), (hlr_ is None)]
+    if not any(check) and all(check):
+        raise ValueError("g1, g2, and hlr must all be provided or all must be None.")
+    if g1_ is not None:
+        g1 = np.array([g1_])
+        g2 = np.array([g2_])
+        hlr = np.array([hlr_])
+        major, minor = get_minor_major_axis(hlr, g1, g2)
+        return minor, major
+
+    # check g1_disk / g2_disk / hlr_disk / g1_bulge / g2_bulge / hlr_bulge / BTT
+    check = [
+        (g1_disk_ is None),
+        (g2_disk_ is None),
+        (hlr_disk_ is None),
+        (g1_bulge_ is None),
+        (g2_bulge_ is None),
+        (hlr_bulge_ is None),
+        (BTT_ is None),
+    ]
+    if not any(check) and all(check):
+        raise ValueError(
+            "g1_disk, g2_disk, hlr_disk, g1_bulge, g2_bulge, hlr_bulge, and BTT must all be provided or all must be None."
+        )
+    if g1_disk_ is not None:
+        g1_disk = np.array([g1_disk_])
+        g2_disk = np.array([g2_disk_])
+        hlr_disk = np.array([hlr_disk_])
+        g1_bulge = np.array([g1_bulge_])
+        g2_bulge = np.array([g2_bulge_])
+        hlr_bulge = np.array([hlr_bulge_])
+        BTT = np.array([BTT_])
+        g1_eff, g2_eff, hlr_eff = get_effective_g_and_hlr(
+            hlr_bulge, hlr_disk, g1_bulge, g2_bulge, g1_disk, g2_disk, BTT
+        )
+        major, minor = get_minor_major_axis(hlr_eff, g1_eff, g2_eff)
+        return minor, major
+
+    return None, None
+
+
+def PhotErr(config, base, value_type):
+    """
+    Return the photometric error for a given magnitude and band (obs_kind).
+    """
+
+    try:
+        photerr_config = galsim.config.GetInputObj("photerr_config", config, base, "PhotErr")
+    except GalSimConfigError:
+        photerr_config = PhotErrConfig()
+
+    req = {"mag": float, "obs_kind": str}
+    opt = {
+        "minor": float,
+        "major": float,
+        "g1": float,
+        "g2": float,
+        "hlr": float,
+        "g1_disk": float,
+        "g2_disk": float,
+        "hlr_disk": float,
+        "g1_bulge": float,
+        "g2_bulge": float,
+        "hlr_bulge": float,
+        "BTT": float,
+        "obj_type": str,
+    }
+    params, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt)
+    mag_ = params["mag"]
+    minor_ = params.get("minor", None)
+    major_ = params.get("major", None)
+    g1_ = params.get("g1", None)
+    g2_ = params.get("g2", None)
+    hlr_ = params.get("hlr", None)
+    g1_disk_ = params.get("g1_disk", None)
+    g2_disk_ = params.get("g2_disk", None)
+    hlr_disk_ = params.get("hlr_disk", None)
+    g1_bulge_ = params.get("g1_bulge", None)
+    g2_bulge_ = params.get("g2_bulge", None)
+    hlr_bulge_ = params.get("hlr_bulge", None)
+    BTT_ = params.get("BTT", None)
+    obj_type = params.get("obj_type", None)
+    obs_kind = params["obs_kind"]
+
+    # Get Euclid band from obs_kind
+    band = get_euclid_band(obs_kind)
+
+    mag = np.atleast_2d(mag_)
+    minor, major = prepare_inputs(
+        minor_,
+        major_,
+        g1_,
+        g2_,
+        hlr_,
+        g1_disk_,
+        g2_disk_,
+        hlr_disk_,
+        g1_bulge_,
+        g2_bulge_,
+        hlr_bulge_,
+        BTT_,
+    )
+
+    euclid_err_model = EuclidWideErrorModel(**photerr_config.get_config(obj_type))
+
+    if minor is None or major is None:
+        euclid_err_model = EuclidWideErrorModel(extendedType="point")
+
+    obs_mag, obs_mag_err, obs_flux = euclid_err_model._get_obs_and_errs(
+        mag - 2.5 * np.log10(photerr_config.gain[band]),
+        major,
+        minor,
+        [band],
+        np.random.default_rng(base["obj_num_seed"]),
+    )
+
+    return obs_mag_err[0][0], safe
+
+
+class PhotErrLoader(InputLoader):
+    def getKwargs(self, config, base, logger):
+        req = {}
+        opt = {
+            "m5": dict,
+            "theta": dict,
+            "extendedType": (str, dict),
+            "gain": dict,
+        }
+
+        kwargs, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt)
+
+        if isinstance(kwargs.get("gain", None), dict):
+            opt = {
+                "VIS": float,
+                "Y": float,
+                "J": float,
+                "H": float,
+            }
+            gains, safe = galsim.config.GetAllParams(kwargs["gain"], base, req={}, opt=opt)
+            kwargs["gain"] = gains
+
+        return kwargs, True
+
+
+class PhotErrConfig:
+    def __init__(self, m5=None, theta=None, extendedType=None, gain=None):
+        self.m5 = m5
+        self.theta = theta
+        if isinstance(extendedType, str):
+            self.extendedType = {"": extendedType}
+        elif isinstance(extendedType, dict):
+            self.extendedType = extendedType
+
+        self._set_gain(gain)
+
+    def get_config(self, obj_type=None):
+        config = {
+            "m5": self.m5,
+            "theta": self.theta,
+        }
+        if obj_type is not None:
+            config["extendedType"] = self.extendedType[obj_type]
+        else:
+            config["extendedType"] = self.extendedType[""]
+        return config
+
+    def _set_gain(self, gain):
+        self.gain = {
+            "VIS": 1.0,
+            "Y": 1.0,
+            "J": 1.0,
+            "H": 1.0,
+        }
+        if isinstance(gain, dict):
+            self.gain.update(gain)
+
+
+RegisterInputType("photerr_config", PhotErrLoader(PhotErrConfig))
+RegisterValueType(
+    "PhotErr",
+    PhotErr,
+    [float, int, None],
+)

--- a/euclidlike_imsim/photometry_error.py
+++ b/euclidlike_imsim/photometry_error.py
@@ -91,7 +91,7 @@ def get_minor_major_axis(hlr, g1, g2):
     Parameters
     ----------
     hlr : float
-        Half-light radius.
+        Half-light radius (in any system of units).
     g1 : float
         First component of the ellipticity.
     g2 : float


### PR DESCRIPTION
We add support to compute Photometry Error using the python package PhotErr. This is principally useful to get catalogue level simulations of the NISP bands for which we are not making images. Several assumptions are mad here so the results are to be taken with a grain of slat.